### PR TITLE
use hmac compare instead of direct compare

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -246,8 +246,20 @@ function Slackbot(configuration) {
                 .update(basestring)
                 .digest('hex');
             let retrievedSignature = req.header('X-Slack-Signature');
+            
+            // Compare the hash of the computed signature with the retrieved signature with a secure hmac compare function
+            const validSignature = () => {
+                
+                const crypto = require('crypto');
 
-            if (hash !== retrievedSignature) {
+                const slackSigBuffer = new Buffer(retrievedSignature);
+                const compSigBuffer = new Buffer(hash);
+
+                return crypto.timingSafeEqual(slackSigBuffer, compSigBuffer);
+            }
+
+            // replace direct compare with the hmac result
+            if (!validSignature()) {
                 slack_botkit.debug('Signature verification failed, Ignoring message');
                 res.status(401);
                 return;


### PR DESCRIPTION
As per https://api.slack.com/docs/verifying-requests-from-slack - "Compare the resulting signature to the header on the request. Note: for best practice, use an hmac compare function instead of directly comparing the signatures for equality."